### PR TITLE
Reinstate windows action job

### DIFF
--- a/.github/workflows/R_CMD_check.yml
+++ b/.github/workflows/R_CMD_check.yml
@@ -3,6 +3,7 @@ on:
     branches:
       - main
       - master
+
   pull_request:
     branches:
       - main
@@ -20,6 +21,7 @@ jobs:
       fail-fast: false
       matrix:
         config:
+          - {os: windows-latest, r: 'release', msystem: MINGW64, arch: x86_64 }
           - {os: macOS-latest, r: 'release'}
           - {os: ubuntu-20.04, r: 'release', rspm: "https://packagemanager.rstudio.com/cran/__linux__/focal/latest"}
           - {os: ubuntu-20.04, r: 'devel', rspm: "https://packagemanager.rstudio.com/cran/__linux__/focal/latest"}
@@ -52,7 +54,7 @@ jobs:
           key: ${{ runner.os }}-${{ hashFiles('.github/R-version') }}-1-${{ hashFiles('.github/depends.Rds') }}
           restore-keys: ${{ runner.os }}-${{ hashFiles('.github/R-version') }}-1-
 
-      - name: Install system dependencies
+      - name: Install linux system dependencies
         if: runner.os == 'Linux'
         run: |
           while read -r cmd
@@ -60,6 +62,14 @@ jobs:
             eval sudo $cmd
           done < <(Rscript -e 'writeLines(remotes::system_requirements("ubuntu", "20.04"))')
       
+      - name: Install windows system dependencies 
+        if: runner.os == 'Windows'
+        uses: msys2/setup-msys2@v2
+        with:
+          msystem: ${{ matrix.config.msystem }}
+          install: git base-devel mingw-w64-${{ matrix.config.arch }}-cmake mingw-w64-${{ matrix.config.arch }}-toolchain mingw-w64-${{ matrix.config.arch }}-glpk mingw-w64-${{ matrix.config.arch }}-gmp mingw-w64-${{ matrix.config.arch }}-zlib mingw-w64-${{ matrix.config.arch }}-libxml2 mingw-w64-${{ matrix.config.arch }}-suitesparse mingw-w64-${{ matrix.config.arch }}-nlopt
+          update: true
+
       - name: Install JAGS macOS
         if: runner.os == 'macOS'
         run: |
@@ -69,6 +79,14 @@ jobs:
       - name: Install JAGS Linux
         if: runner.os == 'Linux'
         run: sudo apt-get install jags
+      
+      - name: Install JAGS Windows
+        if: runner.os == 'Windows'
+        run: |
+          curl.exe -o wjags.exe --url https://deac-fra.dl.sourceforge.net/project/mcmc-jags/JAGS/4.x/Windows/JAGS-4.2.0-Rtools33.exe
+          wjags.exe /S
+          del wjags.exe
+        shell: cmd
         
       - name: Install dependencies
         run: |


### PR DESCRIPTION
Please review code.

I had to install glpk and nlopt, along with the rest of the mingw stuff in the PR.

It was also failing on not having JAGS, so I added that like you already had for the other OS version.

You can see a successful job here: https://github.com/aawhitetech/BUGSnet/actions/runs/1477469997

There is currently one running now if you can wait to validate that it actually works. I did a bunch of squashing and cleanup since the last one so that it is all under one commit.